### PR TITLE
Implementar gestión de edificios y mejoras de incidencias

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,6 +60,9 @@
             <button class="btn" type="button" data-modal-target="modal-filtros">
               Filtros avanzados
             </button>
+            <button class="btn" type="button" data-modal-target="modal-edificios">
+              Gestionar edificios
+            </button>
             <button class="btn" type="button" id="btn-toggle-vista" data-view="lista">
               Ver Kanban
             </button>
@@ -144,24 +147,6 @@
             <span class="resumen-label">Cerradas:</span>
             <span id="resumen-cerradas" class="resumen-value">0</span>
           </div>
-        </section>
-
-        <section
-          id="agenda-vencimientos"
-          class="agenda"
-          aria-labelledby="agenda-vencimientos-titulo"
-        >
-          <div class="agenda-header">
-            <div>
-              <h3 id="agenda-vencimientos-titulo">Agenda de vencimientos</h3>
-              <p class="hint">Fechas clave del mes en curso</p>
-            </div>
-            <div class="agenda-leyenda" aria-hidden="true">
-              <span class="agenda-marcador"></span>
-              <span>Incidencias con fecha límite</span>
-            </div>
-          </div>
-          <div id="agenda-calendario" class="agenda-calendario"></div>
         </section>
 
         <section class="listado" aria-label="Listado de incidencias" data-view="lista">
@@ -275,16 +260,6 @@
           </div>
         </dl>
           <div class="detalle-acciones">
-            <button
-              id="btn-editar-incidencia"
-              class="btn secondary"
-              type="button"
-              data-modal-target="modal-incidencia"
-              data-modal-mode="edit"
-              disabled
-            >
-              Editar incidencia
-            </button>
             <button id="btn-abrir-archivos" class="btn" type="button" disabled>
               Ver archivos
             </button>
@@ -346,6 +321,62 @@
     </main>
 
     <div id="modal-root"></div>
+
+    <!-- INICIO: MODAL-EDIFICIOS -->
+    <dialog
+      id="modal-edificios"
+      class="modal"
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="modal-edificios-titulo"
+    >
+      <div class="modal-content modal-content--wide">
+        <header class="modal-header">
+          <h2 id="modal-edificios-titulo">Gestión de edificios</h2>
+          <button type="button" class="modal-close" data-modal-close aria-label="Cerrar">×</button>
+        </header>
+        <div class="modal-body modal-body--split">
+          <section class="modal-panel">
+            <h3 id="modal-edificios-form-titulo">Añadir edificio</h3>
+            <form id="form-edificio" class="form-edificio">
+              <input type="hidden" id="edificio-id" name="id" />
+              <label for="edificio-nombre">Nombre *</label>
+              <input id="edificio-nombre" name="nombre" type="text" required />
+
+              <label for="edificio-direccion">Dirección</label>
+              <input id="edificio-direccion" name="direccion" type="text" />
+
+              <label for="edificio-contacto">Persona de contacto</label>
+              <input id="edificio-contacto" name="contacto" type="text" />
+
+              <label for="edificio-notas">Notas</label>
+              <textarea id="edificio-notas" name="notas" rows="3"></textarea>
+
+              <p
+                id="edificio-error"
+                class="form-error"
+                role="alert"
+                aria-live="assertive"
+              ></p>
+
+              <div class="modal-footer modal-footer--inline">
+                <button type="submit" class="btn primary" id="btn-guardar-edificio">
+                  Guardar edificio
+                </button>
+                <button type="button" class="btn" id="btn-cancelar-edificio">
+                  Cancelar
+                </button>
+              </div>
+            </form>
+          </section>
+          <section class="modal-panel">
+            <h3 id="modal-edificios-lista-titulo">Edificios registrados</h3>
+            <ul id="lista-edificios" class="lista-edificios"></ul>
+          </section>
+        </div>
+      </div>
+    </dialog>
+    <!-- FIN: MODAL-EDIFICIOS -->
 
     <!-- INICIO: MODAL-INCIDENCIA -->
     <dialog id="modal-incidencia" class="modal" aria-modal="true" role="dialog" aria-labelledby="modal-incidencia-titulo">

--- a/js/services.js
+++ b/js/services.js
@@ -120,6 +120,72 @@ export async function obtenerCatalogo(nombre) {
 }
 
 /**
+ * Crea un nuevo edificio en el catálogo.
+ * @param {{ nombre?: string; direccion?: string; contacto?: string; notas?: string }} datos
+ */
+export async function crearEdificio(datos) {
+  const payload = {
+    nombre: String(datos.nombre ?? "").trim(),
+    direccion: String(datos.direccion ?? "").trim(),
+    contacto: String(datos.contacto ?? "").trim(),
+    notas: String(datos.notas ?? "").trim(),
+  };
+  if (!payload.nombre) {
+    throw new Error("El nombre del edificio es obligatorio");
+  }
+  try {
+    const docRef = await addDoc(collection(db, "edificios"), {
+      ...payload,
+      fechaCreacion: serverTimestamp(),
+      fechaActualizacion: serverTimestamp(),
+    });
+    return docRef.id;
+  } catch (error) {
+    console.error("No se pudo crear el edificio", error);
+    throw error;
+  }
+}
+
+/**
+ * Actualiza un edificio existente.
+ * @param {string} id
+ * @param {{ nombre?: string; direccion?: string; contacto?: string; notas?: string }} datos
+ */
+export async function actualizarEdificio(id, datos) {
+  const payload = {
+    nombre: String(datos.nombre ?? "").trim(),
+    direccion: String(datos.direccion ?? "").trim(),
+    contacto: String(datos.contacto ?? "").trim(),
+    notas: String(datos.notas ?? "").trim(),
+    fechaActualizacion: serverTimestamp(),
+  };
+  if (!payload.nombre) {
+    throw new Error("El nombre del edificio es obligatorio");
+  }
+  try {
+    const refDoc = doc(db, "edificios", id);
+    await updateDoc(refDoc, payload);
+  } catch (error) {
+    console.error("No se pudo actualizar el edificio", error);
+    throw error;
+  }
+}
+
+/**
+ * Elimina un edificio del catálogo.
+ * @param {string} id
+ */
+export async function eliminarEdificio(id) {
+  try {
+    const refDoc = doc(db, "edificios", id);
+    await deleteDoc(refDoc);
+  } catch (error) {
+    console.error("No se pudo eliminar el edificio", error);
+    throw error;
+  }
+}
+
+/**
  * Actualiza el listado de archivos almacenado en la incidencia.
  * @param {string} incidenciaId
  * @param {Array<Record<string, any>>} archivos

--- a/style.css
+++ b/style.css
@@ -335,18 +335,35 @@ textarea {
 
 .lista-incidencias {
   display: grid;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .tarjeta-incidencia {
-  display: grid;
-  gap: 0.4rem;
-  padding: 1.25rem;
   border-radius: var(--radius-md);
   border: 1px solid var(--color-border);
   background: var(--color-surface-alt);
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tarjeta-incidencia--kanban {
+  display: grid;
+  gap: 0.4rem;
+  padding: 1.25rem;
+}
+
+.tarjeta-incidencia--linea {
+  display: grid;
+  grid-template-columns:
+    minmax(0, 2fr)
+    minmax(0, 1.5fr)
+    minmax(0, 1fr)
+    minmax(0, 1fr)
+    minmax(0, 1.2fr)
+    min-content;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
 }
 
 .tarjeta-incidencia:hover,
@@ -361,18 +378,69 @@ textarea {
   box-shadow: 0 0 0 2px rgba(13, 110, 253, 0.2);
 }
 
-.tarjeta-incidencia .titulo {
+.tarjeta-incidencia--kanban .titulo {
   font-size: 1rem;
   font-weight: 700;
   margin: 0;
 }
 
-.tarjeta-incidencia .meta {
+.tarjeta-incidencia--kanban .meta {
   display: flex;
   gap: 0.75rem;
   flex-wrap: wrap;
   font-size: 0.85rem;
   color: var(--color-text-muted);
+}
+
+.tarjeta-incidencia--linea > * {
+  min-width: 0;
+}
+
+.tarjeta-incidencia--linea .linea-titulo {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 700;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.tarjeta-incidencia--linea .linea-edificio,
+.tarjeta-incidencia--linea .linea-fecha {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tarjeta-incidencia--linea .linea-fecha.is-alerta {
+  color: var(--color-danger);
+  font-weight: 600;
+}
+
+.tarjeta-incidencia--linea .linea-fecha.linea-fecha--sin-limite {
+  font-style: italic;
+}
+
+.tarjeta-incidencia--linea .badge {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.6rem;
+}
+
+.tarjeta-incidencia--linea .tarjeta-acciones {
+  justify-content: flex-end;
+  gap: 0.35rem;
+}
+
+.tarjeta-incidencia--linea .tarjeta-acciones-label {
+  display: none;
+}
+
+.tarjeta-incidencia--linea .tarjeta-acciones .btn {
+  padding: 0.35rem 0.6rem;
+  font-size: 0.75rem;
 }
 
 .badge {
@@ -747,6 +815,10 @@ textarea {
   max-height: 90vh;
 }
 
+.modal-content--wide {
+  width: min(960px, 95vw);
+}
+
 .modal-header,
 .modal-footer {
   padding: 1rem 1.5rem;
@@ -766,6 +838,76 @@ textarea {
 
 .modal-body.grid {
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
+.modal-body--split {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.modal-panel {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.modal-panel h3 {
+  margin: 0;
+}
+
+.form-edificio textarea {
+  resize: vertical;
+}
+
+.modal-footer--inline {
+  background: none;
+  padding: 0;
+  justify-content: flex-end;
+  box-shadow: none;
+}
+
+.modal-footer--inline .btn {
+  min-width: 0;
+}
+
+.lista-edificios {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.edificio-item {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface-alt);
+  padding: 0.85rem 1rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.edificio-item header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.edificio-item-titulo {
+  font-weight: 700;
+  margin: 0;
+}
+
+.edificio-item-meta {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.edificio-item-acciones {
+  display: flex;
+  gap: 0.5rem;
 }
 
 .modal-body [data-span="full"] {


### PR DESCRIPTION
## Resumen
- añadir un modal dedicado para crear, editar y eliminar edificios y sincronizar los selectores asociados
- simplificar la lista de incidencias a un formato de línea única y abrir el modal de edición al seleccionar una incidencia
- retirar la agenda/calendario del panel principal y ajustar estilos para los nuevos componentes

## Pruebas
- no se ejecutaron pruebas (no disponibles)

------
https://chatgpt.com/codex/tasks/task_e_68d3c2b5a324832caa476c7e852da1dc