### PR TITLE
Mover historial de anotaciones al modal de edición

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,46 +282,6 @@
             <h4 id="detalle-checklist-titulo">Checklist de resolución</h4>
             <div id="checklist-contenido" class="checklist"></div>
           </section>
-          <section
-            class="detalle-comunicaciones"
-            aria-labelledby="detalle-comunicaciones-titulo"
-          >
-            <div class="detalle-comunicaciones-header">
-              <h4 id="detalle-comunicaciones-titulo">
-                Historial de comunicación
-              </h4>
-              <p class="hint">
-                Registra llamadas, correos o notas vinculadas a la incidencia.
-              </p>
-            </div>
-            <ul id="comunicaciones-lista" class="comunicaciones-lista"></ul>
-            <form id="form-comunicacion" class="form-comunicacion">
-              <div class="form-row">
-                <label for="comunicacion-tipo">Tipo de registro</label>
-                <select id="comunicacion-tipo" name="tipo">
-                  <option value="llamada">Llamada</option>
-                  <option value="correo">Correo</option>
-                  <option value="nota">Nota interna</option>
-                </select>
-              </div>
-              <div class="form-row">
-                <label for="comunicacion-mensaje">Detalle</label>
-                <textarea
-                  id="comunicacion-mensaje"
-                  name="mensaje"
-                  rows="3"
-                  required
-                ></textarea>
-              </div>
-              <p
-                id="comunicacion-error"
-                class="form-error"
-                role="alert"
-                aria-live="assertive"
-              ></p>
-              <button type="submit" class="btn primary">Añadir registro</button>
-            </form>
-          </section>
         </aside>
       </section>
     </main>
@@ -510,68 +470,115 @@
     <!-- FIN: MODAL-POLIZAS -->
 
     <!-- INICIO: MODAL-INCIDENCIA -->
-    <dialog id="modal-incidencia" class="modal" aria-modal="true" role="dialog" aria-labelledby="modal-incidencia-titulo">
-      <form method="dialog" id="form-incidencia" class="modal-content">
-        <header class="modal-header">
-          <h2 id="modal-incidencia-titulo">Nueva incidencia</h2>
-          <button type="button" class="modal-close" data-modal-close aria-label="Cerrar">×</button>
-        </header>
-        <div class="modal-body">
-          <input type="hidden" id="incidencia-id" name="id" />
-          <label for="incidencia-titulo">Título *</label>
-          <input id="incidencia-titulo" name="titulo" type="text" required />
+    <dialog
+      id="modal-incidencia"
+      class="modal"
+      aria-modal="true"
+      role="dialog"
+      aria-labelledby="modal-incidencia-titulo"
+      data-mode="create"
+    >
+      <div class="modal-content modal-content--with-notes">
+        <form method="dialog" id="form-incidencia" class="modal-form">
+          <header class="modal-header">
+            <h2 id="modal-incidencia-titulo">Nueva incidencia</h2>
+            <button type="button" class="modal-close" data-modal-close aria-label="Cerrar">×</button>
+          </header>
+          <div class="modal-body">
+            <input type="hidden" id="incidencia-id" name="id" />
+            <label for="incidencia-titulo">Título *</label>
+            <input id="incidencia-titulo" name="titulo" type="text" required />
 
-          <label for="incidencia-descripcion">Descripción</label>
-          <textarea id="incidencia-descripcion" name="descripcion" rows="4"></textarea>
+            <label for="incidencia-descripcion">Descripción</label>
+            <textarea id="incidencia-descripcion" name="descripcion" rows="4"></textarea>
 
-          <label for="incidencia-estado">Estado</label>
-          <select id="incidencia-estado" name="estado">
-            <option value="abierta">Abierta</option>
-            <option value="en_proceso">En proceso</option>
-            <option value="cerrada">Cerrada</option>
-          </select>
+            <label for="incidencia-estado">Estado</label>
+            <select id="incidencia-estado" name="estado">
+              <option value="abierta">Abierta</option>
+              <option value="en_proceso">En proceso</option>
+              <option value="cerrada">Cerrada</option>
+            </select>
 
-          <label for="incidencia-prioridad">Prioridad</label>
-          <select id="incidencia-prioridad" name="prioridad">
-            <option value="baja">Baja</option>
-            <option value="media">Media</option>
-            <option value="alta">Alta</option>
-            <option value="critica">Crítica</option>
-          </select>
+            <label for="incidencia-prioridad">Prioridad</label>
+            <select id="incidencia-prioridad" name="prioridad">
+              <option value="baja">Baja</option>
+              <option value="media">Media</option>
+              <option value="alta">Alta</option>
+              <option value="critica">Crítica</option>
+            </select>
 
-          <label for="incidencia-edificio">Edificio</label>
-          <select id="incidencia-edificio" name="edificioId"></select>
+            <label for="incidencia-edificio">Edificio</label>
+            <select id="incidencia-edificio" name="edificioId"></select>
 
-          <label for="incidencia-reparador">Reparador</label>
-          <select id="incidencia-reparador" name="reparadorId"></select>
+            <label for="incidencia-reparador">Reparador</label>
+            <select id="incidencia-reparador" name="reparadorId"></select>
 
-          <label for="incidencia-etiquetas">Etiquetas (separadas por comas)</label>
-          <input id="incidencia-etiquetas" name="etiquetas" type="text" />
+            <label for="incidencia-etiquetas">Etiquetas (separadas por comas)</label>
+            <input id="incidencia-etiquetas" name="etiquetas" type="text" />
 
-          <fieldset>
-            <legend>Seguro</legend>
-            <label class="checkbox">
-              <input id="incidencia-siniestro" name="esSiniestro" type="checkbox" />
-              Es siniestro
-            </label>
-            <label for="incidencia-poliza">Póliza</label>
-            <select id="incidencia-poliza" name="polizaId"></select>
-            <label for="incidencia-referencia">Referencia siniestro</label>
-            <input id="incidencia-referencia" name="referenciaSiniestro" type="text" />
-          </fieldset>
+            <fieldset>
+              <legend>Seguro</legend>
+              <label class="checkbox">
+                <input id="incidencia-siniestro" name="esSiniestro" type="checkbox" />
+                Es siniestro
+              </label>
+              <label for="incidencia-poliza">Póliza</label>
+              <select id="incidencia-poliza" name="polizaId"></select>
+              <label for="incidencia-referencia">Referencia siniestro</label>
+              <input id="incidencia-referencia" name="referenciaSiniestro" type="text" />
+            </fieldset>
 
-          <label for="incidencia-fecha-limite">Fecha límite</label>
-          <input id="incidencia-fecha-limite" name="fechaLimite" type="date" />
+            <label for="incidencia-fecha-limite">Fecha límite</label>
+            <input id="incidencia-fecha-limite" name="fechaLimite" type="date" />
 
-          <label for="incidencia-archivo">Archivos</label>
-          <input id="incidencia-archivo" name="archivos" type="file" multiple />
-        </div>
-        <footer class="modal-footer">
-          <span id="incidencia-error" class="form-error" role="alert" aria-live="assertive"></span>
-          <button type="submit" class="btn primary">Guardar</button>
-          <button type="button" class="btn" data-modal-close>Cancelar</button>
-        </footer>
-      </form>
+            <label for="incidencia-archivo">Archivos</label>
+            <input id="incidencia-archivo" name="archivos" type="file" multiple />
+          </div>
+          <footer class="modal-footer">
+            <span id="incidencia-error" class="form-error" role="alert" aria-live="assertive"></span>
+            <button type="submit" class="btn primary">Guardar</button>
+            <button type="button" class="btn" data-modal-close>Cancelar</button>
+          </footer>
+        </form>
+        <section
+          class="modal-comunicaciones detalle-comunicaciones"
+          aria-labelledby="modal-comunicaciones-titulo"
+        >
+          <div class="detalle-comunicaciones-header">
+            <h3 id="modal-comunicaciones-titulo">Historial de comunicación</h3>
+            <p class="hint">
+              Registra llamadas, correos o notas vinculadas a la incidencia.
+            </p>
+          </div>
+          <ul id="comunicaciones-lista" class="comunicaciones-lista"></ul>
+          <form id="form-comunicacion" class="form-comunicacion">
+            <div class="form-row">
+              <label for="comunicacion-tipo">Tipo de registro</label>
+              <select id="comunicacion-tipo" name="tipo">
+                <option value="llamada">Llamada</option>
+                <option value="correo">Correo</option>
+                <option value="nota">Nota interna</option>
+              </select>
+            </div>
+            <div class="form-row">
+              <label for="comunicacion-mensaje">Detalle</label>
+              <textarea
+                id="comunicacion-mensaje"
+                name="mensaje"
+                rows="3"
+                required
+              ></textarea>
+            </div>
+            <p
+              id="comunicacion-error"
+              class="form-error"
+              role="alert"
+              aria-live="assertive"
+            ></p>
+            <button type="submit" class="btn primary">Añadir registro</button>
+          </form>
+        </section>
+      </div>
     </dialog>
     <!-- FIN: MODAL-INCIDENCIA -->
 

--- a/js/main.js
+++ b/js/main.js
@@ -160,6 +160,9 @@ function setupEventListeners() {
     const triggerIncidencia = target.closest('[data-modal-target="modal-incidencia"]');
     if (triggerIncidencia) {
       const mode = triggerIncidencia.getAttribute("data-modal-mode") ?? "create";
+      if (refs.modalIncidencia) {
+        refs.modalIncidencia.dataset.mode = mode;
+      }
       actualizarTituloModalIncidencia(mode);
       if (mode === "create") {
         refs.formIncidencia?.reset();
@@ -550,6 +553,9 @@ function setupEventListeners() {
   refs.btnEditarIncidencia?.addEventListener("click", () => {
     if (!state.seleccion) return;
     prepararFormularioIncidencia(state.seleccion);
+    if (refs.modalIncidencia) {
+      refs.modalIncidencia.dataset.mode = "edit";
+    }
     if (refs.modalIncidencia instanceof HTMLDialogElement) {
       openModal(refs.modalIncidencia);
     }

--- a/style.css
+++ b/style.css
@@ -815,6 +815,36 @@ textarea {
   max-height: 90vh;
 }
 
+.modal-content--with-notes {
+  gap: 0;
+  overflow: hidden;
+  background: var(--color-surface);
+}
+
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  width: 100%;
+}
+
+.modal-form .modal-body {
+  flex: 1 1 auto;
+}
+
+.modal-comunicaciones {
+  margin-top: 0;
+  padding: 1.5rem;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
+  overflow-y: auto;
+  max-height: 40vh;
+}
+
+#modal-incidencia[data-mode="create"] .modal-comunicaciones {
+  display: none;
+}
+
 .modal-content--wide {
   width: min(960px, 95vw);
 }


### PR DESCRIPTION
## Summary
- mueve el historial de comunicaciones desde el panel principal al modal de incidencia
- reestructura el modal para mostrar el listado y formulario de anotaciones solo en modo edición
- ajusta estilos y manejo de estado del modal para ocultar el bloque en modo creación

## Testing
- no se ejecutaron pruebas automatizadas (app estática)


------
https://chatgpt.com/codex/tasks/task_e_68d3d45bf050832c9537b980f68fdb74