### PR TITLE
Mejora modales de reparadores y pólizas

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,8 +406,27 @@
             </form>
           </section>
           <section class="modal-panel">
-            <h3 id="modal-reparadores-lista-titulo">Reparadores registrados</h3>
-            <ul id="lista-reparadores" class="lista-reparadores"></ul>
+            <div class="catalogo-panel-header" aria-live="off">
+              <div class="catalogo-panel-title">
+                <h3 id="modal-reparadores-lista-titulo">Reparadores registrados</h3>
+                <p id="reparador-resumen" class="catalogo-resumen" aria-live="polite"></p>
+              </div>
+              <div class="catalogo-busqueda">
+                <label class="sr-only" for="reparador-busqueda">Buscar reparador</label>
+                <input
+                  id="reparador-busqueda"
+                  type="search"
+                  placeholder="Buscar reparador"
+                  aria-describedby="reparador-busqueda-ayuda"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <p id="reparador-busqueda-ayuda" class="hint">
+                  Filtra por nombre, especialidad o datos de contacto. Pulsa Escape para limpiar.
+                </p>
+              </div>
+            </div>
+            <ul id="lista-reparadores" class="lista-reparadores" aria-live="polite"></ul>
           </section>
         </div>
       </div>
@@ -469,8 +488,27 @@
             </form>
           </section>
           <section class="modal-panel">
-            <h3 id="modal-polizas-lista-titulo">Pólizas registradas</h3>
-            <ul id="lista-polizas" class="lista-polizas"></ul>
+            <div class="catalogo-panel-header" aria-live="off">
+              <div class="catalogo-panel-title">
+                <h3 id="modal-polizas-lista-titulo">Pólizas registradas</h3>
+                <p id="poliza-resumen" class="catalogo-resumen" aria-live="polite"></p>
+              </div>
+              <div class="catalogo-busqueda">
+                <label class="sr-only" for="poliza-busqueda">Buscar póliza</label>
+                <input
+                  id="poliza-busqueda"
+                  type="search"
+                  placeholder="Buscar póliza"
+                  aria-describedby="poliza-busqueda-ayuda"
+                  autocomplete="off"
+                  spellcheck="false"
+                />
+                <p id="poliza-busqueda-ayuda" class="hint">
+                  Filtra por nombre, compañía o datos de contacto. Pulsa Escape para limpiar.
+                </p>
+              </div>
+            </div>
+            <ul id="lista-polizas" class="lista-polizas" aria-live="polite"></ul>
           </section>
         </div>
       </div>

--- a/style.css
+++ b/style.css
@@ -1000,6 +1000,47 @@ textarea {
   gap: 0.75rem;
 }
 
+.catalogo-panel-header {
+  display: grid;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.catalogo-panel-title {
+  display: grid;
+  gap: 0.25rem;
+}
+
+.catalogo-panel-header h3 {
+  margin: 0;
+}
+
+.catalogo-resumen {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.catalogo-busqueda {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.catalogo-busqueda input {
+  width: 100%;
+}
+
+.catalogo-busqueda .hint {
+  margin: 0;
+}
+
+@media (min-width: 720px) {
+  .catalogo-panel-header {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+  }
+}
+
 .edificio-item,
 .reparador-item,
 .poliza-item {


### PR DESCRIPTION
## Resumen
- Añadí buscadores y textos de resumen accesibles a los catálogos de reparadores y pólizas dentro de sus modales.
- Actualicé la lógica de la aplicación para gestionar filtros en memoria, aplicar la búsqueda en vivo y recalcular los totales mostrados.
- Incorporé estilos específicos para el nuevo encabezado de catálogo y el campo de búsqueda en ambos modales.

## Pruebas
- No se ejecutaron pruebas automatizadas (no se proporcionaron comandos).


------
https://chatgpt.com/codex/tasks/task_e_68d405eed89c832c8a6d3505531d04f1